### PR TITLE
Adds rphenoscape aș a suggested dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,9 +36,9 @@ Depends: R (>= 3.5.0)
 Imports: ape, phytools, corHMM, pracma, dplyr, tidyr, MASS, numbers,
         treeplyr, rphenoscape, ontologyIndex, purrr, readr, stringr,
         ontoFAST, grDevices, graphics, igraph
-Suggests: tidyverse, rmarkdown, knitr, testthat (>= 3.0.0)
+Suggests: tidyverse, rmarkdown, knitr, testthat (>= 3.0.0), rphenoscape (>= 0.3.0)
 VignetteBuilder: knitr
-Remotes: uyedaj/rphenoscate
+Remotes: phenoscape/rphenoscape
 RoxygenNote: 7.2.3
 Config/testthat/edition: 3
 NeedsCompilation: no


### PR DESCRIPTION
Also puts the GitHub remote for rphenoscape so it can automatically be installed.

Note that there is no reason to give the GitHub repo for _this_ package in the `Remotes:` field, it's only used for dependencies.